### PR TITLE
Make the query template parameters more extensible

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -37,7 +37,7 @@ mergeable:
     validate:
       - do: label
         must_include:
-          regex: 'New Issue :new:|Bug :bug:'
+          regex: 'New Issue|Bug'
     pass:
       - do: comment
         payload:

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,8 @@ all: init
 	$(CMAKE) --build $(BUILD_DIR) --target all -- -j$(JOBS)
 
 
-$(BUILD_DIR)/test/unit/tests.tsk:
-	$(CMAKE) --build $(BUILD_DIR) --target tests -- -j$(JOBS)
-
 build-test: init $(BUILD_DIR)/test/unit/tests.tsk
+	$(CMAKE) --build $(BUILD_DIR) --target tests -- -j$(JOBS)
 
 exec-test:
 	@cd $(BUILD_DIR) && \

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: init
 	$(CMAKE) --build $(BUILD_DIR) --target all -- -j$(JOBS)
 
 
-build-test: init $(BUILD_DIR)/test/unit/tests.tsk
+build-test: init 
 	$(CMAKE) --build $(BUILD_DIR) --target tests -- -j$(JOBS)
 
 exec-test:

--- a/include/sqlwizardry/v1/detail/macro.hpp
+++ b/include/sqlwizardry/v1/detail/macro.hpp
@@ -71,9 +71,10 @@ struct name<BOOST_PP_TUPLE_REM()specialisation> {\
 };
 
 #define SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(name)\
+template <typename MODEL, typename DB, typename... ELEMENTS>\
 struct name {\
-    const Query<MODEL, DB, SELECT, WHERE, ORDER_BY, LIMIT>& query;\
-    constexpr name(const sqlwizardry::Query<MODEL, DB, SELECT, WHERE, ORDER_BY, LIMIT>& q) : query{q} {}\
+    const Query<MODEL, DB, ELEMENTS...>& query;\
+    constexpr name(const sqlwizardry::Query<MODEL, DB, ELEMENTS...>& q) : query{q} {}\
     void operator()(std::ostream& ss) {
 #define SQLWIZARDRY_DECLARE_END_SERIALISER\
     }\

--- a/include/sqlwizardry/v1/detail/type.hpp
+++ b/include/sqlwizardry/v1/detail/type.hpp
@@ -1,6 +1,8 @@
 #ifndef INCLUDED_SQLWIZARDRY_V1_DETAIL_TYPE_HPP
 #define INCLUDED_SQLWIZARDRY_V1_DETAIL_TYPE_HPP
 
+#include <type_traits>
+
 namespace sqlwizardry {
 struct empty{};
 
@@ -8,6 +10,55 @@ struct select_tag {};
 struct where_tag {};
 struct order_tag {};
 struct limit_tag {};
+
+template <typename K, typename V>
+struct KVType {
+    using key_type = K;
+    using value_type = V;
+    V value;
+    constexpr KVType(V val) : value{std::move(val)} {}
+};
+
+template <typename K, typename V>
+constexpr auto kv(V&& value) {
+    return KVType<K, std::decay_t<V>>{std::forward<V>(value)};
+}
+
+template <typename... V>
+struct type_of;
+
+template <typename TAG>
+struct type_of<TAG>{
+    using type = KVType<TAG, empty>;
+};
+template <typename TAG, typename K, typename V>
+struct type_of<TAG, KVType<K, V>>{
+    using type = std::decay_t<std::conditional_t<std::is_same_v<TAG, K>, KVType<K,V>, KVType<K, empty>>>;
+};
+template <typename TAG, typename K, typename V, typename... REST>
+struct type_of<TAG, KVType<K, V>, REST...>{
+    using type = std::decay_t<std::conditional_t<std::is_same_v<TAG, K>, KVType<K,V>, typename type_of<TAG, REST...>::type>>;
+};
+
+template <typename TAG, typename ...T>
+using type_of_t = typename type_of<TAG, T...>::type;
+
+
+
+
+template <typename TAG>
+constexpr auto value_of() {
+    return empty{};
+} 
+
+template <typename TAG, template <typename, typename> class KVTypeT, typename K, typename V, typename... REST>
+constexpr auto value_of(KVTypeT<K,V> kv, REST&&... rest) {
+    if constexpr(std::is_same_v<TAG, K>) {
+        return kv.value;
+    } else {
+        return value_of<TAG>(std::forward<REST>(rest)...);
+    }
+} 
 }
 
 #endif


### PR DESCRIPTION
# Description

Create a compile time KV pack that can be used to pass the elements in any order, tagging them where appropriate. As part of this change we also moved the sub element serialisers out of query serialiser as it is likely that callers may want to create db specific partial overrides.

**Fixes #16 **

## Rationale

It was getting difficult to continue to extend the positional based template parmameters indefinitely.

## Checklist

- [X] **I have written unit tests.**
- [X] **I have checked previous issues for a discussions around my particular problem**
- [X] **I have run the test suite locally and confirmed that my change does not introduce any regressions**