### PR TITLE
Add some more tests and add limit/offset support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,6 @@ BreakBeforeBraces: Allman
 BreakStringLiterals: 'true'
 Cpp11BracedListStyle: 'true'
 SpaceAfterTemplateKeyword: 'true'
-Standard: Cpp11
+Standard: Cpp17
 UseTab: Never
 ColumnLimit: 140
-...

--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,6 @@ BreakBeforeBraces: Allman
 BreakStringLiterals: 'true'
 Cpp11BracedListStyle: 'true'
 SpaceAfterTemplateKeyword: 'true'
-Standard: Cpp17
+Standard: Cpp11
 UseTab: Never
 ColumnLimit: 140

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ## Introduction
 
-sqlwizardry is a C++ based ORM mechanism that prioritises compile-time vaalidation and compoability. This allows the developer to write statements such as:
+sqlwizardry is a C++ based ORM mechanism that prioritises compile-time
+vaalidation and compoability. This allows the developer to write statements such
+as:
 
 ```cpp
 
@@ -28,4 +30,9 @@ result.begin();
 }
 ```
 
-The above would be translated to an SQL statement run against a  particular database of particular type. At compile time the framework would induce an assertion if a given statement does not make sense or a particular DB does not support the type of statement you are attempting to run. All with an extremely performant compile time framework and the ability to create database objects ready-to-go in memory.
+The above would be translated to an SQL statement run against a particular
+database of particular type. At compile time the framework would induce an
+assertion if a given statement does not make sense or a particular DB does not
+support the type of statement you are attempting to run. All with an extremely
+performant compile time framework and the ability to create database objects
+ready-to-go in memory.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SQLWizardry
 
-[![Continuous Integration](https://github.com/HeavyHat/sqlwizardry/actions/workflows/build.yml/badge.svg)](https://github.com/HeavyHat/sqlwizardry/actions/workflows/build.yml)
+[![Main Branch Build](https://github.com/HeavyHat/sqlwizardry/actions/workflows/Main.yml/badge.svg)](https://github.com/HeavyHat/sqlwizardry/actions/workflows/Main.yml)
+[![codecov](https://codecov.io/gh/HeavyHat/cruel/branch/master/graph/badge.svg?token=CQVID09241)](https://codecov.io/gh/HeavyHat/cruel)
+[![CodeFactor](https://www.codefactor.io/repository/github/heavyhat/sqlwizardry/badge)](https://www.codefactor.io/repository/github/heavyhat/sqlwizardry)
 
 ## Introduction
 

--- a/include/sqlwizardry/v1/detail/macro.hpp
+++ b/include/sqlwizardry/v1/detail/macro.hpp
@@ -51,7 +51,8 @@ template <typename T>\
 struct name {\
     const T& element;\
     constexpr name(const T& col) : element{col} {}\
-    void operator()(std::ostream& ss) {
+    template <typename STREAM_T> \
+    void operator()(STREAM_T& ss) {
 #define SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER\
     }\
 };
@@ -65,7 +66,8 @@ template <BOOST_PP_TUPLE_REM()type_params>\
 struct name<BOOST_PP_TUPLE_REM()specialisation> {\
     const BOOST_PP_TUPLE_REM()element_type& element;\
     constexpr name(const BOOST_PP_TUPLE_REM()element_type& col) : element{col} {}\
-    void operator()(std::ostream& ss) {
+    template <typename STREAM_T> \
+    void operator()(STREAM_T& ss) {
 #define SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER\
     }\
 };
@@ -75,7 +77,8 @@ template <typename MODEL, typename DB, typename... ELEMENTS>\
 struct name {\
     const Query<MODEL, DB, ELEMENTS...>& query;\
     constexpr name(const sqlwizardry::Query<MODEL, DB, ELEMENTS...>& q) : query{q} {}\
-    void operator()(std::ostream& ss) {
+    template <typename STREAM_T> \
+    void operator()(STREAM_T& ss) {
 #define SQLWIZARDRY_DECLARE_END_SERIALISER\
     }\
 };

--- a/include/sqlwizardry/v1/detail/macro.hpp
+++ b/include/sqlwizardry/v1/detail/macro.hpp
@@ -1,86 +1,96 @@
 #ifndef INCLUDED_SQLWIZARDRY_V1_DETAIL_MACRO_HPP
 #define INCLUDED_SQLWIZARDRY_V1_DETAIL_MACRO_HPP
 
-#include <boost/preprocessor/tuple/eat.hpp>
-#include <boost/preprocessor/tuple/rem.hpp>
-#include <boost/preprocessor/tuple/pop_back.hpp>
 #include <boost/preprocessor/empty.hpp>
-#include <boost/preprocessor/variadic/to_seq.hpp>
-#include <boost/preprocessor/variadic/to_tuple.hpp>
 #include <boost/preprocessor/seq/for_each_i.hpp>
 #include <boost/preprocessor/stringize.hpp>
+#include <boost/preprocessor/tuple/eat.hpp>
+#include <boost/preprocessor/tuple/pop_back.hpp>
+#include <boost/preprocessor/tuple/rem.hpp>
+#include <boost/preprocessor/variadic/to_seq.hpp>
+#include <boost/preprocessor/variadic/to_tuple.hpp>
 
 // Helpers for generating definitions of named types to describe the AST.
-#define SQLWIZARDRY_DEFINE_COMPOUND_BINARY(X)\
-template <typename A, typename B>\
-struct X {\
-    using type = sqlwizardry::condition_type::binary;\
-    using category = sqlwizardry::condition_category::compound;\
-    A condition_a;\
-    B condition_b;\
+#define SQLWIZARDRY_DEFINE_COMPOUND_BINARY(X)                                       \
+  template <typename A, typename B>                                                 \
+  struct X                                                                          \
+  {                                                                                 \
+    using type = sqlwizardry::condition_type::binary;                               \
+    using category = sqlwizardry::condition_category::compound;                     \
+    A condition_a;                                                                  \
+    B condition_b;                                                                  \
     constexpr X(A a, B b) : condition_a{std::move(a)}, condition_b{std::move(b)} {} \
-};
-#define SQLWIZARDRY_DEFINE_COMPOUND_UNARY(X)\
-template <typename T>\
-struct X {\
-    using type = sqlwizardry::condition_type::unary;\
-    using category = sqlwizardry::condition_category::compound;\
-    T condition;\
-    explicit constexpr X(T cond) : condition{std::move(cond)} {}\
-};
-#define SQLWIZARDRY_DEFINE_TERMINAL_UNARY(X) \
-template <typename MODEL, typename T, typename T1>\
-struct X {\
-    using type = sqlwizardry::condition_type::unary;\
-    using category = sqlwizardry::condition_category::terminal;\
-    const sqlwizardry::ColumnDefinition<MODEL, T>& column;\
-    T1 value;\
-    constexpr X(const sqlwizardry::ColumnDefinition<MODEL, T>& col, T1 val) : column{std::move(col)}, value{std::move(val)} {}\
-};
-
+  };
+#define SQLWIZARDRY_DEFINE_COMPOUND_UNARY(X)                     \
+  template <typename T>                                          \
+  struct X                                                       \
+  {                                                              \
+    using type = sqlwizardry::condition_type::unary;             \
+    using category = sqlwizardry::condition_category::compound;  \
+    T condition;                                                 \
+    explicit constexpr X(T cond) : condition{std::move(cond)} {} \
+  };
+#define SQLWIZARDRY_DEFINE_TERMINAL_UNARY(X)                                                                                   \
+  template <typename MODEL, typename T, typename T1>                                                                           \
+  struct X                                                                                                                     \
+  {                                                                                                                            \
+    using type = sqlwizardry::condition_type::unary;                                                                           \
+    using category = sqlwizardry::condition_category::terminal;                                                                \
+    const sqlwizardry::ColumnDefinition<MODEL, T>& column;                                                                     \
+    T1 value;                                                                                                                  \
+    constexpr X(const sqlwizardry::ColumnDefinition<MODEL, T>& col, T1 val) : column{std::move(col)}, value{std::move(val)} {} \
+  };
 
 // Helper to map an operator to a AST type.
 #define SQLWIZARDRY_DEFINE_COMPOUND_TERMINAL_OPERATOR_MAPPING(X, Operator) \
-[[nodiscard]] constexpr auto operator Operator(const type& criteria) const { \
-    return sqlwizardry::ColumnPredicate{X{*this, criteria}};\
-}
+  [[nodiscard]] constexpr auto operator Operator(const type& criteria) const { return sqlwizardry::ColumnPredicate{X{*this, criteria}}; }
 
+#define SQLWIZARDRY_DECLARE_BEGIN_ELEMENT_SERIALISER(name) \
+  template <typename T>                                    \
+  struct name                                              \
+  {                                                        \
+    const T& element;                                      \
+    constexpr name(const T& col) : element{col} {}         \
+    template <typename STREAM_T>                           \
+    void operator()(STREAM_T& ss)                          \
+    {
+#define SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER \
+  }                                                \
+  }                                                \
+  ;
 
-#define SQLWIZARDRY_DECLARE_BEGIN_ELEMENT_SERIALISER(name)\
-template <typename T>\
-struct name {\
-    const T& element;\
-    constexpr name(const T& col) : element{col} {}\
-    template <typename STREAM_T> \
-    void operator()(STREAM_T& ss) {
-#define SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER\
-    }\
-};
+#define SQLWIZARDRY_DECLARE_TYPE_SPECIALISED_ELEMENT_SERIALISER(name, type_params) \
+  template <BOOST_PP_TUPLE_REM() type_params>                                      \
+  struct name                                                                      \
+  {                                                                                \
+  };
 
-#define SQLWIZARDRY_DECLARE_TYPE_SPECIALISED_ELEMENT_SERIALISER(name, type_params)\
-template <BOOST_PP_TUPLE_REM()type_params>\
-struct name {};
+#define SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(name, type_params, element_type, specialisation) \
+  template <BOOST_PP_TUPLE_REM() type_params>                                                                     \
+  struct name<BOOST_PP_TUPLE_REM() specialisation>                                                                \
+  {                                                                                                               \
+    const BOOST_PP_TUPLE_REM() element_type& element;                                                             \
+    constexpr name(const BOOST_PP_TUPLE_REM() element_type& col) : element{col} {}                                \
+    template <typename STREAM_T>                                                                                  \
+    void operator()(STREAM_T& ss)                                                                                 \
+    {
+#define SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER \
+  }                                                            \
+  }                                                            \
+  ;
 
-#define SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(name, type_params, element_type, specialisation)\
-template <BOOST_PP_TUPLE_REM()type_params>\
-struct name<BOOST_PP_TUPLE_REM()specialisation> {\
-    const BOOST_PP_TUPLE_REM()element_type& element;\
-    constexpr name(const BOOST_PP_TUPLE_REM()element_type& col) : element{col} {}\
-    template <typename STREAM_T> \
-    void operator()(STREAM_T& ss) {
-#define SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER\
-    }\
-};
-
-#define SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(name)\
-template <typename MODEL, typename DB, typename... ELEMENTS>\
-struct name {\
-    const Query<MODEL, DB, ELEMENTS...>& query;\
-    constexpr name(const sqlwizardry::Query<MODEL, DB, ELEMENTS...>& q) : query{q} {}\
-    template <typename STREAM_T> \
-    void operator()(STREAM_T& ss) {
-#define SQLWIZARDRY_DECLARE_END_SERIALISER\
-    }\
-};
+#define SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(name)                                    \
+  template <typename MODEL, typename DB, typename... ELEMENTS>                        \
+  struct name                                                                         \
+  {                                                                                   \
+    const Query<MODEL, DB, ELEMENTS...>& query;                                       \
+    constexpr name(const sqlwizardry::Query<MODEL, DB, ELEMENTS...>& q) : query{q} {} \
+    template <typename STREAM_T>                                                      \
+    void operator()(STREAM_T& ss)                                                     \
+    {
+#define SQLWIZARDRY_DECLARE_END_SERIALISER \
+  }                                        \
+  }                                        \
+  ;
 
 #endif

--- a/include/sqlwizardry/v1/detail/type.hpp
+++ b/include/sqlwizardry/v1/detail/type.hpp
@@ -10,6 +10,7 @@ struct select_tag {};
 struct where_tag {};
 struct order_tag {};
 struct limit_tag {};
+struct offset_tag {};
 
 template <typename K, typename V>
 struct KVType {

--- a/include/sqlwizardry/v1/detail/type.hpp
+++ b/include/sqlwizardry/v1/detail/type.hpp
@@ -3,63 +3,83 @@
 
 #include <type_traits>
 
-namespace sqlwizardry {
-struct empty{};
+namespace sqlwizardry
+{
+struct empty
+{
+};
 
-struct select_tag {};
-struct where_tag {};
-struct order_tag {};
-struct limit_tag {};
-struct offset_tag {};
-
-template <typename K, typename V>
-struct KVType {
-    using key_type = K;
-    using value_type = V;
-    V value;
-    constexpr KVType(V val) : value{std::move(val)} {}
+struct select_tag
+{
+};
+struct where_tag
+{
+};
+struct order_tag
+{
+};
+struct limit_tag
+{
+};
+struct offset_tag
+{
 };
 
 template <typename K, typename V>
-constexpr auto kv(V&& value) {
-    return KVType<K, std::decay_t<V>>{std::forward<V>(value)};
+struct KVType
+{
+  using key_type = K;
+  using value_type = V;
+  V value;
+  constexpr KVType(V val) : value{std::move(val)} {}
+};
+
+template <typename K, typename V>
+constexpr auto kv(V&& value)
+{
+  return KVType<K, std::decay_t<V>>{std::forward<V>(value)};
 }
 
 template <typename... V>
 struct type_of;
 
 template <typename TAG>
-struct type_of<TAG>{
-    using type = KVType<TAG, empty>;
+struct type_of<TAG>
+{
+  using type = KVType<TAG, empty>;
 };
 template <typename TAG, typename K, typename V>
-struct type_of<TAG, KVType<K, V>>{
-    using type = std::decay_t<std::conditional_t<std::is_same_v<TAG, K>, KVType<K,V>, KVType<K, empty>>>;
+struct type_of<TAG, KVType<K, V>>
+{
+  using type = std::decay_t<std::conditional_t<std::is_same_v<TAG, K>, KVType<K, V>, KVType<K, empty>>>;
 };
 template <typename TAG, typename K, typename V, typename... REST>
-struct type_of<TAG, KVType<K, V>, REST...>{
-    using type = std::decay_t<std::conditional_t<std::is_same_v<TAG, K>, KVType<K,V>, typename type_of<TAG, REST...>::type>>;
+struct type_of<TAG, KVType<K, V>, REST...>
+{
+  using type = std::decay_t<std::conditional_t<std::is_same_v<TAG, K>, KVType<K, V>, typename type_of<TAG, REST...>::type>>;
 };
 
-template <typename TAG, typename ...T>
+template <typename TAG, typename... T>
 using type_of_t = typename type_of<TAG, T...>::type;
 
-
-
-
 template <typename TAG>
-constexpr auto value_of() {
-    return empty{};
-} 
+constexpr auto value_of()
+{
+  return empty{};
+}
 
 template <typename TAG, template <typename, typename> class KVTypeT, typename K, typename V, typename... REST>
-constexpr auto value_of(KVTypeT<K,V> kv, REST&&... rest) {
-    if constexpr(std::is_same_v<TAG, K>) {
-        return kv.value;
-    } else {
-        return value_of<TAG>(std::forward<REST>(rest)...);
-    }
-} 
+constexpr auto value_of(KVTypeT<K, V> kv, REST&&... rest)
+{
+  if constexpr (std::is_same_v<TAG, K>)
+  {
+    return kv.value;
+  }
+  else
+  {
+    return value_of<TAG>(std::forward<REST>(rest)...);
+  }
 }
+}  // namespace sqlwizardry
 
 #endif

--- a/include/sqlwizardry/v1/query.hpp
+++ b/include/sqlwizardry/v1/query.hpp
@@ -1,162 +1,172 @@
 #ifndef INCLUDED_SQLWIZARDRY_V1_QUERY_HPP
 #define INCLUDED_SQLWIZARDRY_V1_QUERY_HPP
 
-#include <tuple>
-#include <utility>
-#include <sstream>
-#include <type_traits>
-
 #include <sqlwizardry/v1/column.hpp>
-#include <sqlwizardry/v1/detail/type.hpp>
 #include <sqlwizardry/v1/detail/reflection.hpp>
+#include <sqlwizardry/v1/detail/type.hpp>
+#include <sstream>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
-namespace sqlwizardry {
-
+namespace sqlwizardry
+{
 template <typename MODEL, typename DATABASE, typename... ELEMENTS>
-struct AllQuery; 
+struct AllQuery;
 
 template <typename MODEL, typename DATABASE, typename... ELEMENTS>
 class Query;
 
-namespace detail {
-    template <typename COLUMNS>
-    constexpr auto get_ordering(COLUMNS column) {
-        if constexpr(is_ordering_v<std::decay_t<COLUMNS>>) {
-            return column;
-        }
-        else {
-            return column::Ascending{std::move(column)};
-        }
-    }
-
-    template <typename... COLUMNS>
-    constexpr auto get_ordering_tuple(COLUMNS... cols) {
-        return std::make_tuple(get_ordering(std::move(cols))...);
-    }
-    
-
-    template <typename MODEL, typename DB, typename... T>
-    constexpr auto make_query(DB& db, T&& ...ELEMENTS) {
-        return Query<MODEL, DB, std::decay_t<T>...>{db, std::forward<T>(ELEMENTS)...};
-    }
+namespace detail
+{
+template <typename COLUMNS>
+constexpr auto get_ordering(COLUMNS column)
+{
+  if constexpr (is_ordering_v<std::decay_t<COLUMNS>>)
+  {
+    return column;
+  }
+  else
+  {
+    return column::Ascending{std::move(column)};
+  }
 }
 
 template <typename... COLUMNS>
-constexpr auto get_ordering_tuple(COLUMNS... cols) {
-    return std::make_tuple(detail::get_ordering(std::move(cols))...);
+constexpr auto get_ordering_tuple(COLUMNS... cols)
+{
+  return std::make_tuple(get_ordering(std::move(cols))...);
 }
 
+template <typename MODEL, typename DB, typename... T>
+constexpr auto make_query(DB& db, T&&... ELEMENTS)
+{
+  return Query<MODEL, DB, std::decay_t<T>...>{db, std::forward<T>(ELEMENTS)...};
+}
+}  // namespace detail
+
+template <typename... COLUMNS>
+constexpr auto get_ordering_tuple(COLUMNS... cols)
+{
+  return std::make_tuple(detail::get_ordering(std::move(cols))...);
+}
 
 template <typename MODEL, typename DATABASE, typename... ELEMENTS>
-struct AllQuery; 
+struct AllQuery;
 
 template <typename MODEL, typename DATABASE, typename... ELEMENTS>
-class Query {
-    protected:
-    DATABASE& db;
-    type_of_t<select_tag,ELEMENTS...> _select;
-    type_of_t<where_tag,ELEMENTS...> _where;
-    type_of_t<order_tag,ELEMENTS...> _order_by;
-    type_of_t<limit_tag,ELEMENTS...> _limit;
-    type_of_t<offset_tag,ELEMENTS...> _offset;
+class Query
+{
+ protected:
+  DATABASE& db;
+  type_of_t<select_tag, ELEMENTS...> _select;
+  type_of_t<where_tag, ELEMENTS...> _where;
+  type_of_t<order_tag, ELEMENTS...> _order_by;
+  type_of_t<limit_tag, ELEMENTS...> _limit;
+  type_of_t<offset_tag, ELEMENTS...> _offset;
 
-    public:
+ public:
+  constexpr Query(DATABASE& db, ELEMENTS... e)
+      : db{db},
+        _select{std::move(value_of<select_tag>(e...))},
+        _where{std::move(value_of<where_tag>(e...))},
+        _order_by{std::move(value_of<order_tag>(e...))},
+        _limit{std::move(value_of<limit_tag>(e...))},
+        _offset{std::move(value_of<offset_tag>(e...))}
+  {
+  }
 
-    constexpr Query(DATABASE& db, ELEMENTS... e) 
-        : db{db}, 
-        _select{std::move(value_of<select_tag>(e...))}, 
-        _where{std::move(value_of<where_tag>(e...))}, 
-        _order_by{std::move(value_of<order_tag>(e...))}, 
-        _limit{std::move(value_of<limit_tag>(e...))}, 
-        _offset{std::move(value_of<offset_tag>(e...))} {
-
+  template <typename... COLUMNS>
+  [[nodiscard]] constexpr auto select(COLUMNS&&... cols)
+  {
+    static_assert(is_empty_v<decltype(_select.value)>, "Selection already made in this query,");
+    if constexpr (sizeof...(cols) == 0)
+    {
+      auto fields = get_columns<MODEL>();
+      return detail::make_query<MODEL>(db, kv<select_tag>(std::move(fields)), std::move(_where), std::move(_order_by), std::move(_limit),
+                                       std::move(_offset));
     }
-
-    template <typename ...COLUMNS>
-    [[nodiscard]] constexpr auto select(COLUMNS&& ...cols) {
-        static_assert(is_empty_v<decltype(_select.value)>, "Selection already made in this query,");
-        if constexpr(sizeof...(cols) == 0) {
-            auto fields = get_columns<MODEL>();
-            return detail::make_query<MODEL>(db, kv<select_tag>(std::move(fields)), std::move(_where), std::move(_order_by), std::move(_limit),std::move(_offset));
-        } else {
-            return detail::make_query<MODEL>(db, kv<select_tag>(std::make_tuple(cols...)), std::move(_where), std::move(_order_by), std::move(_limit),std::move(_offset));
-        }
+    else
+    {
+      return detail::make_query<MODEL>(db, kv<select_tag>(std::make_tuple(cols...)), std::move(_where), std::move(_order_by),
+                                       std::move(_limit), std::move(_offset));
     }
+  }
 
-    template <typename PREDICATE>
-    [[nodiscard]] constexpr auto where(PREDICATE&& pred) {
-        if constexpr(is_empty_v<decltype(_where.value)>) {
-            return detail::make_query<MODEL>(db, std::move(_select), kv<where_tag>(std::forward<PREDICATE>(pred)), std::move(_order_by), std::move(_limit),std::move(_offset));
-        } else {
-            return detail::make_query<MODEL>(db, std::move(_select), kv<where_tag>(_where.value && std::forward<PREDICATE>(pred)), std::move(_order_by), std::move(_limit),std::move(_offset));
-        }
+  template <typename PREDICATE>
+  [[nodiscard]] constexpr auto where(PREDICATE&& pred)
+  {
+    if constexpr (is_empty_v<decltype(_where.value)>)
+    {
+      return detail::make_query<MODEL>(db, std::move(_select), kv<where_tag>(std::forward<PREDICATE>(pred)), std::move(_order_by),
+                                       std::move(_limit), std::move(_offset));
     }
+    else
+    {
+      return detail::make_query<MODEL>(db, std::move(_select), kv<where_tag>(_where.value && std::forward<PREDICATE>(pred)),
+                                       std::move(_order_by), std::move(_limit), std::move(_offset));
+    }
+  }
 
-    template <typename ...ORDERING>
-    [[nodiscard]] constexpr auto order_by(ORDERING&& ...order){
-        static_assert(is_empty_v<decltype(_order_by.value)>, "This query already has an ordering specified");
-        auto ordering = get_ordering_tuple(std::forward<ORDERING>(order)...);
-        return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), kv<order_tag>(std::move(ordering)), std::move(_limit),std::move(_offset));
-    }
+  template <typename... ORDERING>
+  [[nodiscard]] constexpr auto order_by(ORDERING&&... order)
+  {
+    static_assert(is_empty_v<decltype(_order_by.value)>, "This query already has an ordering specified");
+    auto ordering = get_ordering_tuple(std::forward<ORDERING>(order)...);
+    return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), kv<order_tag>(std::move(ordering)), std::move(_limit),
+                                     std::move(_offset));
+  }
 
-    [[nodiscard]] constexpr auto limit(std::size_t l){
-        return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), kv<limit_tag>(l),std::move(_offset));
-    }
+  [[nodiscard]] constexpr auto limit(std::size_t l)
+  {
+    return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), kv<limit_tag>(l), std::move(_offset));
+  }
 
-    template <std::size_t L>
-    [[nodiscard]] constexpr auto limit(){
-        static_assert(L > 0, "Limit must be greater than 0");
-        return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), kv<limit_tag>(L),std::move(_offset));
-    }
+  template <std::size_t L>
+  [[nodiscard]] constexpr auto limit()
+  {
+    static_assert(L > 0, "Limit must be greater than 0");
+    return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), kv<limit_tag>(L), std::move(_offset));
+  }
 
-    [[nodiscard]] constexpr auto offset(std::size_t l){
-        return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), std::move(_limit), kv<offset_tag>(l));
-    }
+  [[nodiscard]] constexpr auto offset(std::size_t l)
+  {
+    return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), std::move(_limit), kv<offset_tag>(l));
+  }
 
-    template <std::size_t L>
-    [[nodiscard]] constexpr auto offset(){
-        return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), std::move(_limit),kv<offset_tag>(L));
-    }
+  template <std::size_t L>
+  [[nodiscard]] constexpr auto offset()
+  {
+    return detail::make_query<MODEL>(db, std::move(_select), std::move(_where), std::move(_order_by), std::move(_limit), kv<offset_tag>(L));
+  }
 
-    [[nodiscard]] constexpr const auto& get_select() const {
-        return _select.value;
-    }
+  [[nodiscard]] constexpr const auto& get_select() const { return _select.value; }
 
-    [[nodiscard]] constexpr const auto& get_where() const {
-        return _where.value;
-    }
+  [[nodiscard]] constexpr const auto& get_where() const { return _where.value; }
 
-    [[nodiscard]] constexpr const auto& get_order() const {
-        return _order_by.value;
-    }
+  [[nodiscard]] constexpr const auto& get_order() const { return _order_by.value; }
 
-    [[nodiscard]] constexpr const auto& get_limit() const {
-        return _limit.value;
-    }
+  [[nodiscard]] constexpr const auto& get_limit() const { return _limit.value; }
 
-    [[nodiscard]] constexpr const auto& get_offset() const {
-        return _offset.value;
-    }
+  [[nodiscard]] constexpr const auto& get_offset() const { return _offset.value; }
 
-    [[nodiscard]] constexpr auto& get_db() {
-        return db;
-    }
+  [[nodiscard]] constexpr auto& get_db() { return db; }
 
-    [[nodiscard]] constexpr auto all() {
-        static_assert(!is_empty_v<decltype(_select.value)>, "This query needs at leas one selection. Did you forget to call .select()?");
-        return AllQuery<MODEL, DATABASE, ELEMENTS...>{*this};
-    }
+  [[nodiscard]] constexpr auto all()
+  {
+    static_assert(!is_empty_v<decltype(_select.value)>, "This query needs at leas one selection. Did you forget to call .select()?");
+    return AllQuery<MODEL, DATABASE, ELEMENTS...>{*this};
+  }
 };
 
-
-
-
 template <typename CRTP>
-struct model {
-    template <typename DB>
-    [[nodiscard]] static constexpr auto query(DB& database ) {
-        return Query<CRTP,DB>{database};
-    }    
+struct model
+{
+  template <typename DB>
+  [[nodiscard]] static constexpr auto query(DB& database)
+  {
+    return Query<CRTP, DB>{database};
+  }
 };
 
 template <typename MODEL, typename DB, typename... ELEMENTS>
@@ -165,22 +175,21 @@ struct query_serialiser;
 template <typename MODEL, typename DATABASE, typename... ELEMENTS>
 class AllQuery : private Query<MODEL, DATABASE, ELEMENTS...>
 {
-    using QUERY_T = Query<MODEL, DATABASE, ELEMENTS...>;
-    public:
+  using QUERY_T = Query<MODEL, DATABASE, ELEMENTS...>;
 
-    constexpr AllQuery(Query<MODEL, DATABASE, ELEMENTS...> q) : QUERY_T{std::move(q)} {}
+ public:
+  constexpr AllQuery(Query<MODEL, DATABASE, ELEMENTS...> q) : QUERY_T{std::move(q)} {}
 
-    auto begin() {
-        std::stringstream ss;
-        query_serialiser{*this}(ss);
-        auto& db = QUERY_T::get_db();
-        db.run(ss.str());
-    }
-    
-    auto end() {
+  auto begin()
+  {
+    std::stringstream ss;
+    query_serialiser{*this}(ss);
+    auto& db = QUERY_T::get_db();
+    db.run(ss.str());
+  }
 
-    }
+  auto end() {}
 };
-}
+}  // namespace sqlwizardry
 
 #endif

--- a/include/sqlwizardry/v1/serialiser.hpp
+++ b/include/sqlwizardry/v1/serialiser.hpp
@@ -2,211 +2,187 @@
 #ifndef INCLUDED_SQLWIZARDRY_V1_SERIALISER_HPP
 #define INCLUDED_SQLWIZARDRY_V1_SERIALISER_HPP
 
-#include <type_traits>
-#include <ostream>
 #include <iomanip>
-
-#include <sqlwizardry/v1/detail/traits.hpp>
+#include <ostream>
 #include <sqlwizardry/v1/detail/macro.hpp>
+#include <sqlwizardry/v1/detail/traits.hpp>
 #include <sqlwizardry/v1/predicate.hpp>
+#include <type_traits>
 
-namespace sqlwizardry {
-    SQLWIZARDRY_DECLARE_BEGIN_ELEMENT_SERIALISER(select_element)
-    ss << element.table_name << "." << element.name;
-    SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER
+namespace sqlwizardry
+{
+SQLWIZARDRY_DECLARE_BEGIN_ELEMENT_SERIALISER(select_element)
+ss << element.table_name << "." << element.name;
+SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(select)
-    ss << "SELECT ";
-    std::apply([&ss](const auto& ...args) {
-            int column = 0;
-            int dummy[] = {
-                ((select_element{args}(ss), column++ ? ss : ss << ", "),0)...
-            };
-        },
-        query.get_select()
-    );
-    SQLWIZARDRY_DECLARE_END_SERIALISER
+SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(select)
+ss << "SELECT ";
+std::apply(
+    [&ss](const auto&... args) {
+      int column = 0;
+      int dummy[] = {((select_element{args}(ss), column++ ? ss : ss << ", "), 0)...};
+    },
+    query.get_select());
+SQLWIZARDRY_DECLARE_END_SERIALISER
 
+SQLWIZARDRY_DECLARE_BEGIN_ELEMENT_SERIALISER(from_element)
+ss << element.table_name;
+SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER
 
+SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(from)
+ss << " FROM ";
+from_element{std::get<0>(query.get_select())}(ss);
+SQLWIZARDRY_DECLARE_END_SERIALISER
 
-    SQLWIZARDRY_DECLARE_BEGIN_ELEMENT_SERIALISER(from_element)
-    ss << element.table_name;
-    SQLWIZARDRY_DECLARE_END_ELEMENT_SERIALISER
+SQLWIZARDRY_DECLARE_TYPE_SPECIALISED_ELEMENT_SERIALISER(where_element, (typename, typename = void))
 
-    SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(from)
-    ss << " FROM ";
-    from_element{std::get<0>(query.get_select())}(ss);
-    SQLWIZARDRY_DECLARE_END_SERIALISER
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename T), (ColumnPredicate<T>),
+                                                         (ColumnPredicate<T>, std::void_t<>))
+where_element<std::decay_t<T>>{element.condition}(ss);
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_DECLARE_TYPE_SPECIALISED_ELEMENT_SERIALISER(where_element, (typename,typename=void))
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename T1, typename T2), (Or<T1, T2>),
+                                                         (Or<T1, T2>, std::void_t<>))
+ss << " (";
+where_element{element.condition_a}(ss);
+ss << " OR ";
+where_element{element.condition_b}(ss);
+ss << ")";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename T), 
-    (ColumnPredicate<T>), 
-    (ColumnPredicate<T>, std::void_t<>))
-        where_element<std::decay_t<T>>{element.condition}(ss);
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename T1, typename T2), (And<T1, T2>),
+                                                         (And<T1, T2>, std::void_t<>))
+ss << " (";
+where_element<std::decay_t<T1>>{element.condition_a}(ss);
+ss << " AND ";
+where_element<std::decay_t<T2>>{element.condition_b}(ss);
+ss << ")";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename T1, typename T2), 
-    (Or<T1, T2>), 
-    (Or<T1, T2>, std::void_t<>))
-        ss << " (";
-        where_element{element.condition_a}(ss);
-        ss << " OR ";
-        where_element{element.condition_b}(ss);
-        ss << ")";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename T), (Not<T>), (Not<T>, std::void_t<>))
+ss << " NOT (";
+where_element<std::decay_t<T>>{element.condition}(ss);
+ss << ")";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename T1, typename T2), 
-    (And<T1, T2>), 
-    (And<T1, T2>, std::void_t<>))
-        ss << " (";
-        where_element<std::decay_t<T1>>{element.condition_a}(ss);
-        ss << " AND ";
-        where_element<std::decay_t<T2>>{element.condition_b}(ss);
-        ss << ")";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename M, typename T1, typename T2), (Equals<M, T1, T2>),
+                                                         (Equals<M, T1, T2>, std::void_t<>))
+ss << M::table_name << "." << element.column.name << " = ";
+where_element<std::decay_t<T2>>{element.value}(ss);
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename T), 
-    (Not<T>), 
-    (Not<T>, std::void_t<>))
-        ss << " NOT (";
-        where_element<std::decay_t<T>>{element.condition}(ss);
-        ss << ")";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename M, typename T1, typename T2), (NotEquals<M, T1, T2>),
+                                                         (NotEquals<M, T1, T2>, std::void_t<>))
+ss << M::table_name << "." << element.column.name << " <> ";
+where_element<std::decay_t<T2>>{element.value}(ss);
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
 
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename M, typename T1, typename T2), 
-    (Equals<M, T1, T2>), 
-    (Equals<M, T1, T2>, std::void_t<>))
-        ss << M::table_name << "." << element.column.name << " = ";
-        where_element<std::decay_t<T2>>{element.value}(ss);
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename M, typename T1, typename T2), 
-    (NotEquals<M, T1, T2>), 
-    (NotEquals<M, T1, T2>, std::void_t<>))
-        ss << M::table_name << "." << element.column.name << " <> ";
-        where_element<std::decay_t<T2>>{element.value}(ss);
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename M, typename T1, typename T2), 
-    (In<M, T1, T2>), 
-    (In<M, T1, T2>, std::void_t<>))
-        ss << element.column.table_name << "." << element.column.name << " IN (";
-        bool first = true;
-        for(const auto& val : element.value){
-            if(!first) {
-                ss << ",";
-            }
-            where_element<std::decay_t<decltype(val)>>{val}(ss);
-            first = false;
-        }
-        ss << ")";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename M, typename T1, typename T2), 
-    (Not<In<M, T1, T2>>), 
-    (Not<In<M, T1, T2>>, std::void_t<>))
-        ss << element.condition.column.table_name << "." << element.condition.column.name << " NOT IN (";
-        bool first = true;
-        for(const auto& val : element.condition.value){
-            if(!first) {
-                ss << ",";
-            }
-            where_element<std::decay_t<decltype(val)>>{val}(ss);
-            first = false;
-        }
-        ss << ")";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename T1), 
-    (T1), 
-    (T1, std::enable_if_t<std::is_arithmetic_v<T1>>))
-        ss << element;
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, 
-    (typename T1), 
-    (T1), 
-    (T1, std::enable_if_t<is_string<T1>::value>))
-        ss << std::quoted(element);
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-
-    SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(where)
-    using where_t = typename type_of_t<where_tag, ELEMENTS...>::value_type;
-    if constexpr(!is_empty_v<where_t>) {
-        ss << " WHERE ";
-        where_element<std::decay_t<where_t>>{query.get_where()}(ss);
-    }
-    SQLWIZARDRY_DECLARE_END_SERIALISER
-
-    SQLWIZARDRY_DECLARE_TYPE_SPECIALISED_ELEMENT_SERIALISER(order_element, (typename))
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(order_element, 
-    (typename T1), 
-    (column::Ascending<T1>), 
-    (column::Ascending<T1>))
-        ss << element.column.table_name << "." << element.column.name << " ASC";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(order_element, 
-    (typename T1), 
-    (column::Descending<T1>), 
-    (column::Descending<T1>))
-        ss << element.column.table_name << "." << element.column.name << " DESC";
-    SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
-
-    SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(order)
-    using order_t = typename type_of_t<order_tag, ELEMENTS...>::value_type;
-    if constexpr(!is_empty_v<order_t>) {
-        ss << " ORDER BY ";
-        std::apply([&ss](const auto& ...order) {
-            int column = 0;
-            int dummy[] = {
-                ((order_element<std::decay_t<decltype(order)>>{order}(ss), !column++ ? ss : ss << ", "),0)...
-            };
-        },query.get_order());
-    }
-    SQLWIZARDRY_DECLARE_END_SERIALISER
-
-    SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(limit)
-    using limit_t = typename type_of_t<limit_tag, ELEMENTS...>::value_type;
-    if constexpr(!is_empty_v<limit_t>) {
-        ss << " LIMIT " << query.get_limit();
-    }
-    SQLWIZARDRY_DECLARE_END_SERIALISER
-
-    SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(offset)
-    using offset_t = typename type_of_t<offset_tag, ELEMENTS...>::value_type;
-    if constexpr(!is_empty_v<offset_t>) {
-        ss << " OFFSET " << query.get_offset();
-    }
-    SQLWIZARDRY_DECLARE_END_SERIALISER
-
-template <typename MODEL, typename DB, typename ...ELEMENTS>
-struct query_serialiser {
-    const Query<MODEL, DB, ELEMENTS...>& query;
-    query_serialiser(const Query<MODEL, DB, ELEMENTS...>& q) : query{q} {}
-
-    auto operator()(std::ostream& ss) {
-        select{query}(ss);
-        from{query}(ss);
-        where{query}(ss);
-        order{query}(ss);
-        limit{query}(ss);
-        offset{query}(ss);
-    }
-
-};
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename M, typename T1, typename T2), (In<M, T1, T2>),
+                                                         (In<M, T1, T2>, std::void_t<>))
+ss << element.column.table_name << "." << element.column.name << " IN (";
+bool first = true;
+for (const auto& val : element.value)
+{
+  if (!first)
+  {
+    ss << ",";
+  }
+  where_element<std::decay_t<decltype(val)>>{val}(ss);
+  first = false;
 }
+ss << ")";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename M, typename T1, typename T2), (Not<In<M, T1, T2>>),
+                                                         (Not<In<M, T1, T2>>, std::void_t<>))
+ss << element.condition.column.table_name << "." << element.condition.column.name << " NOT IN (";
+bool first = true;
+for (const auto& val : element.condition.value)
+{
+  if (!first)
+  {
+    ss << ",";
+  }
+  where_element<std::decay_t<decltype(val)>>{val}(ss);
+  first = false;
+}
+ss << ")";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename T1), (T1),
+                                                         (T1, std::enable_if_t<std::is_arithmetic_v<T1>>))
+ss << element;
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(where_element, (typename T1), (T1), (T1, std::enable_if_t<is_string<T1>::value>))
+ss << std::quoted(element);
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+
+SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(where)
+using where_t = typename type_of_t<where_tag, ELEMENTS...>::value_type;
+if constexpr (!is_empty_v<where_t>)
+{
+  ss << " WHERE ";
+  where_element<std::decay_t<where_t>>{query.get_where()}(ss);
+}
+SQLWIZARDRY_DECLARE_END_SERIALISER
+
+SQLWIZARDRY_DECLARE_TYPE_SPECIALISED_ELEMENT_SERIALISER(order_element, (typename))
+
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(order_element, (typename T1), (column::Ascending<T1>), (column::Ascending<T1>))
+ss << element.column.table_name << "." << element.column.name << " ASC";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+
+SQLWIZARDRY_BEGIN_TYPE_SPECIALISATION_ELEMENT_SERIALISER(order_element, (typename T1), (column::Descending<T1>), (column::Descending<T1>))
+ss << element.column.table_name << "." << element.column.name << " DESC";
+SQLWIZARDRY_END_TYPE_SPECIALISATION_ELEMENT_SERIALISER
+
+SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(order)
+using order_t = typename type_of_t<order_tag, ELEMENTS...>::value_type;
+if constexpr (!is_empty_v<order_t>)
+{
+  ss << " ORDER BY ";
+  std::apply(
+      [&ss](const auto&... order) {
+        int column = 0;
+        int dummy[] = {((order_element<std::decay_t<decltype(order)>>{order}(ss), !column++ ? ss : ss << ", "), 0)...};
+      },
+      query.get_order());
+}
+SQLWIZARDRY_DECLARE_END_SERIALISER
+
+SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(limit)
+using limit_t = typename type_of_t<limit_tag, ELEMENTS...>::value_type;
+if constexpr (!is_empty_v<limit_t>)
+{
+  ss << " LIMIT " << query.get_limit();
+}
+SQLWIZARDRY_DECLARE_END_SERIALISER
+
+SQLWIZARDRY_DECLARE_BEGIN_SERIALISER(offset)
+using offset_t = typename type_of_t<offset_tag, ELEMENTS...>::value_type;
+if constexpr (!is_empty_v<offset_t>)
+{
+  ss << " OFFSET " << query.get_offset();
+}
+SQLWIZARDRY_DECLARE_END_SERIALISER
+
+template <typename MODEL, typename DB, typename... ELEMENTS>
+struct query_serialiser
+{
+  const Query<MODEL, DB, ELEMENTS...>& query;
+  query_serialiser(const Query<MODEL, DB, ELEMENTS...>& q) : query{q} {}
+
+  auto operator()(std::ostream& ss)
+  {
+    select{query}(ss);
+    from{query}(ss);
+    where{query}(ss);
+    order{query}(ss);
+    limit{query}(ss);
+    offset{query}(ss);
+  }
+};
+}  // namespace sqlwizardry
 
 #endif

--- a/test/unit/declaration.cpp
+++ b/test/unit/declaration.cpp
@@ -8,7 +8,29 @@ SQLWIZARDRY_TABLE(User,
     (Column<std::string>) password
 )
 
-TEST(Declaration, BasicTableDeclaration) {
+
+TEST(Declaration, BasicTableDeclarationSelect) {
+    std::stringstream ss;
+    sqlwizardry::engine::Debug debugEngine{ss};
+    auto results = User::query(debugEngine)
+        .select()
+        .all();
+    results.begin();
+    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user\n");
+}
+
+TEST(Declaration, BasicTableDeclarationSelectWithPred) {
+    std::stringstream ss;
+    sqlwizardry::engine::Debug debugEngine{ss};
+    auto results = User::query(debugEngine)
+        .select()
+        .where(User::username == "Heavyhat")
+        .all();
+    results.begin();
+    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\"\n");
+}
+
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrder) {
     std::stringstream ss;
     sqlwizardry::engine::Debug debugEngine{ss};
     auto results = User::query(debugEngine)
@@ -18,4 +40,60 @@ TEST(Declaration, BasicTableDeclaration) {
         .all();
     results.begin();
     EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC\n");
+}
+
+
+
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimit) {
+    std::stringstream ss;
+    sqlwizardry::engine::Debug debugEngine{ss};
+    auto results = User::query(debugEngine)
+        .select()
+        .where(User::username == "Heavyhat")
+        .order_by(User::username)
+        .limit(1)
+        .all();
+    results.begin();
+    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1\n");
+}
+
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimit2) {
+    std::stringstream ss;
+    sqlwizardry::engine::Debug debugEngine{ss};
+    auto results = User::query(debugEngine)
+        .select()
+        .where(User::username == "Heavyhat")
+        .order_by(User::username)
+        .limit<1>()
+        .all();
+    results.begin();
+    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1\n");
+}
+
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimitAndOffSet) {
+    std::stringstream ss;
+    sqlwizardry::engine::Debug debugEngine{ss};
+    auto results = User::query(debugEngine)
+        .select()
+        .where(User::username == "Heavyhat")
+        .order_by(User::username)
+        .limit(1)
+        .offset(1)
+        .all();
+    results.begin();
+    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1 OFFSET 1\n");
+}
+
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimitAndOffset2) {
+    std::stringstream ss;
+    sqlwizardry::engine::Debug debugEngine{ss};
+    auto results = User::query(debugEngine)
+        .select()
+        .where(User::username == "Heavyhat")
+        .order_by(User::username)
+        .limit<1>()
+        .offset<1>()
+        .all();
+    results.begin();
+    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1 OFFSET 1\n");
 }

--- a/test/unit/declaration.cpp
+++ b/test/unit/declaration.cpp
@@ -1,99 +1,76 @@
-#include <sqlwizardry/v1/all.hpp>
 #include <gtest/gtest.h>
 
+#include <sqlwizardry/v1/all.hpp>
+
 using namespace sqlwizardry::column;
-SQLWIZARDRY_TABLE(User,
-    "user",
-    (Column<std::string>) username,
-    (Column<std::string>) password
-)
+SQLWIZARDRY_TABLE(User, "user", (Column<std::string>)username, (Column<std::string>)password)
 
-
-TEST(Declaration, BasicTableDeclarationSelect) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user\n");
+TEST(Declaration, BasicTableDeclarationSelect)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results = User::query(debugEngine).select().all();
+  results.begin();
+  EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user\n");
 }
 
-TEST(Declaration, BasicTableDeclarationSelectWithPred) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .where(User::username == "Heavyhat")
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\"\n");
+TEST(Declaration, BasicTableDeclarationSelectWithPred)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results = User::query(debugEngine).select().where(User::username == "Heavyhat").all();
+  results.begin();
+  EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\"\n");
 }
 
-TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrder) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .where(User::username == "Heavyhat")
-        .order_by(User::username)
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC\n");
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrder)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results = User::query(debugEngine).select().where(User::username == "Heavyhat").order_by(User::username).all();
+  results.begin();
+  EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC\n");
 }
 
-
-
-TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimit) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .where(User::username == "Heavyhat")
-        .order_by(User::username)
-        .limit(1)
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1\n");
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimit)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results = User::query(debugEngine).select().where(User::username == "Heavyhat").order_by(User::username).limit(1).all();
+  results.begin();
+  EXPECT_EQ(ss.str(),
+            "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1\n");
 }
 
-TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimit2) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .where(User::username == "Heavyhat")
-        .order_by(User::username)
-        .limit<1>()
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1\n");
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimit2)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results = User::query(debugEngine).select().where(User::username == "Heavyhat").order_by(User::username).limit<1>().all();
+  results.begin();
+  EXPECT_EQ(ss.str(),
+            "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1\n");
 }
 
-TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimitAndOffSet) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .where(User::username == "Heavyhat")
-        .order_by(User::username)
-        .limit(1)
-        .offset(1)
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1 OFFSET 1\n");
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimitAndOffSet)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results = User::query(debugEngine).select().where(User::username == "Heavyhat").order_by(User::username).limit(1).offset(1).all();
+  results.begin();
+  EXPECT_EQ(
+      ss.str(),
+      "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1 OFFSET 1\n");
 }
 
-TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimitAndOffset2) {
-    std::stringstream ss;
-    sqlwizardry::engine::Debug debugEngine{ss};
-    auto results = User::query(debugEngine)
-        .select()
-        .where(User::username == "Heavyhat")
-        .order_by(User::username)
-        .limit<1>()
-        .offset<1>()
-        .all();
-    results.begin();
-    EXPECT_EQ(ss.str(), "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1 OFFSET 1\n");
+TEST(Declaration, BasicTableDeclarationSelectWithPredAndOrderAndLimitAndOffset2)
+{
+  std::stringstream ss;
+  sqlwizardry::engine::Debug debugEngine{ss};
+  auto results =
+      User::query(debugEngine).select().where(User::username == "Heavyhat").order_by(User::username).limit<1>().offset<1>().all();
+  results.begin();
+  EXPECT_EQ(
+      ss.str(),
+      "SELECT user.username, user.password FROM user WHERE user.username = \"Heavyhat\" ORDER BY user.username ASC LIMIT 1 OFFSET 1\n");
 }


### PR DESCRIPTION
# Description

Add the ability to have both Ct and non-CT limit and offset statements in the query builder and the serialiser.

**Fixes #10**
**Fixes #12 **

## Rationale

Unsupported use-case previously.

## Checklist

- [X] **I have written unit tests.**
- [X] **I have checked previous issues for a discussions around my particular problem**
- [X] **I have run the test suite locally and confirmed that my change does not introduce any regressions**